### PR TITLE
Specify repository and licence to erase warnings by node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "chrome-mysql-admin",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:yoichiro/chrome_mysql_admin.git"
+  },
+  "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
I set licence according to the comment of app/scripts/background.js.