### PR TITLE
raise version of grunt-bower-task

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-bower-task": "^0.3.4",
+    "grunt-bower-task": "^0.4.0",
     "grunt-chrome-manifest": "~0.2.0",
     "grunt-concurrent": "^0.3.1",
     "grunt-contrib-clean": "^0.5.0",


### PR DESCRIPTION
I tried these commands to according to the README:

```bash
$ git clone https://github.com/yoichiro/chrome_mysql_admin.git
$ cd chrome_mysql_admin
$ npm install
$ grunt
```

But got this error:

```
Fatal error: Arguments to path.join must be strings
```

By googling, I found node on my machine and grunt-bower-task are incompatible.

Then, I modified the version of the package and make it to build.

Pages I found https://github.com/yatskevich/grunt-bower-task/issues/122

# My environment

```
> node --version
v0.12.4

> grunt --version
grunt-cli v0.1.13
grunt v0.4.5
```

I might get something wrong because I'm new to node and grunt (and modern JavaScript development).
Thanks in advance.