### PR TITLE
(WIP) enable auto reload without livereload

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -54,6 +54,27 @@ module.exports = function (grunt) {
                     '<%= yeoman.app %>/manifest.json',
                     '<%= yeoman.app %>/_locales/{,*/}*.json'
                 ]
+            },
+            app: {
+                options: {
+                    spawn: true,
+                    atBegin: true
+                },
+                tasks: ['shell:loadAndLaunch'],
+                files: [
+                    // TODO: abstract app files array
+                    '<%= yeoman.app %>/*.html',
+                    '<%= yeoman.app %>/templates/*.html',
+                    '<%= yeoman.app %>/styles/{,*/}*.css',
+                    '<%= yeoman.app %>/scripts/{,*/}*.js',
+                    '<%= yeoman.app %>/scripts/window/{,*/}*.js',
+                    '<%= yeoman.app %>/scripts/window/controller/{,*/}*.js',
+                    '<%= yeoman.app %>/scripts/window/services/{,*/}*.js',
+                    '<%= yeoman.app %>/scripts/window/utils/{,*/}*.js',
+                    '<%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}',
+                    '<%= yeoman.app %>/manifest.json',
+                    '<%= yeoman.app %>/_locales/{,*/}*.json'
+                ]
             }
         },
         connect: {
@@ -223,6 +244,10 @@ module.exports = function (grunt) {
                     'make',
                     'cd ../..'
                 ].join(';')
+            },
+            loadAndLaunch: {
+                // TODO: support other releases of google chrome: such as google-chrome-beta
+                command: 'google-chrome-stable --load-and-launch-app=app/'
             }
         }
     });


### PR DESCRIPTION
Added a grunt task to (re)load the app automatically.

Unfortunately, livereload is not well-supported on platforms other than Mac:
- Windows version is still alpha (and I don't want to develop on it).
- For Linux, only [guard-livereload](https://github.com/guard/guard-livereload) is available, which is no more maintained.

So I looked for a way to make grunt automatically reload the app without livereload,
then found one to use Chrome's `--load-and-launch-app=` option.
According to [the doc](https://developer.chrome.com/apps/first_app), Chrome just reloads the app when already launched.
That is, it is possible to reload automatically by executing `google-chrome --load-and-launch-app=app/` continuously by `grunt watch`.
That's why I sent this pull request.

But there's a problem I have to discuss with you:
I should extract some variables to be more flexible or DRY (as written as TODOs).
But where should I put the variable? The top level of Gruntfile or other? 

I'm sorry but I'm new to grunt.
I'm glad if you give me some advice!
Thanks!
