### PR TITLE
Confirm before rendering an ER diagram.

### DIFF
--- a/app/scripts/window/controllers/navbar_controller.js
+++ b/app/scripts/window/controllers/navbar_controller.js
@@ -39,7 +39,7 @@ chromeMyAdmin.controller("NavbarController", ["$scope", "mySQLClientService", "m
         $scope.$on(Events.REFRESH_DATABASES, function(event, data) {
             loadDatabaseList();
         });
-        $scope.$on(Events.SHOW_ER_DIALOG, function(event, data) {
+        $scope.$on(Events.SHOW_ER_DIAGRAM, function(event, data) {
             modeService.changeMode(Modes.ER_DIAGRAM);
         });
     };
@@ -143,10 +143,10 @@ chromeMyAdmin.controller("NavbarController", ["$scope", "mySQLClientService", "m
 
     $scope.selectERDiagram = function() {
         $scope.showConfirmDialog(
-            "Render an ER dialog of the DB?\nIt might take more than a minute depending on the number of the tables.",
+            "Render an ER diagram of the DB?\nIt might take more than a minute depending on the number of the tables.",
             "Yes",
             "No",
-            Events.SHOW_ER_DIALOG,
+            Events.SHOW_ER_DIAGRAM,
             false
         );
     };

--- a/app/scripts/window/controllers/navbar_controller.js
+++ b/app/scripts/window/controllers/navbar_controller.js
@@ -39,6 +39,9 @@ chromeMyAdmin.controller("NavbarController", ["$scope", "mySQLClientService", "m
         $scope.$on(Events.REFRESH_DATABASES, function(event, data) {
             loadDatabaseList();
         });
+        $scope.$on(Events.SHOW_ER_DIALOG, function(event, data) {
+            modeService.changeMode(Modes.ER_DIAGRAM);
+        });
     };
 
     $scope.initialize = function() {
@@ -139,7 +142,14 @@ chromeMyAdmin.controller("NavbarController", ["$scope", "mySQLClientService", "m
     };
 
     $scope.selectERDiagram = function() {
-        modeService.changeMode(Modes.ER_DIAGRAM);
+        $scope.showConfirmDialog(
+            "Render an ER dialog of the DB?\nIt might take more than a minute depending on the number of the tables.",
+            "Yes",
+            "No",
+            Events.SHOW_ER_DIALOG,
+            false
+        );
     };
+
 
 }]);

--- a/app/scripts/window/utils/constants.js
+++ b/app/scripts/window/utils/constants.js
@@ -25,6 +25,7 @@ chromeMyAdmin.constant("Events", {
     SHOW_PROGRESS_BAR: "showProgressBar",
     SHOW_CHANGE_WINDOW_PANEL: "showChangeWindowPanel",
     SHOW_CONFIRM_DIALOG: "showConfirmDialog",
+    SHOW_ER_DIALOG: "showERDialog",
     SHOW_ERROR_DIALOG: "showErrorDialog",
     SHOW_ADD_COLUMN_DIALOG: "showAddColumnDialog",
     SHOW_ADD_INDEX_DIALOG: "showAddIndexDialog",

--- a/app/scripts/window/utils/constants.js
+++ b/app/scripts/window/utils/constants.js
@@ -25,7 +25,7 @@ chromeMyAdmin.constant("Events", {
     SHOW_PROGRESS_BAR: "showProgressBar",
     SHOW_CHANGE_WINDOW_PANEL: "showChangeWindowPanel",
     SHOW_CONFIRM_DIALOG: "showConfirmDialog",
-    SHOW_ER_DIALOG: "showERDialog",
+    SHOW_ER_DIAGRAM: "showERDiagram",
     SHOW_ERROR_DIALOG: "showErrorDialog",
     SHOW_ADD_COLUMN_DIALOG: "showAddColumnDialog",
     SHOW_ADD_INDEX_DIALOG: "showAddIndexDialog",


### PR DESCRIPTION
Clicking the ER diagram button when opening a database with dozens of tables,
it takes a long time for the app to calculate the relations of the tables to render.
And the app doesn't accept any input during the caluculaation.

So I often get annoyed by clicking the ER diagram button by mistake.
Especially when opening production database, I want to hold back the load to the database as much as possible.

Then, how about confirming when clicking the ER diagram button before rendering?
I'll appreciate any other idea.