### PR TITLE
Beautify dependencies declaration with ng-annotate

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,6 +96,22 @@ module.exports = function (grunt) {
                 'test/spec/{,*/}*.js'
             ]
         },
+        ngAnnotate: {
+            all: {
+                files: [
+                    {
+                        expand: true,
+                        src: [
+                            '<%= yeoman.app %>/scripts/window/{,*/}.js',
+                            '<%= yeoman.app %>/scripts/window/controllers/{,*/}*.js',
+                            '<%= yeoman.app %>/scripts/window/services/{,*/}*.js',
+                            '<%= yeoman.app %>/scripts/window/utils/{,*/}*.js'
+                        ],
+                        dest: '<%= yeoman.dist %>'
+                    }
+                ]
+            }
+        },
         useminPrepare: {
             options: {
                 dest: '<%= yeoman.dist %>'
@@ -251,6 +267,7 @@ module.exports = function (grunt) {
         'make',
         'copy:angular_csp_css',
         'chromeManifest:dist',
+        'ngAnnotate',
         'useminPrepare',
         'concurrent:dist',
         'concat',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,6 +140,15 @@ module.exports = function (grunt) {
                 }]
             }
         },
+        concat: {
+            files: {
+                src: [
+                    '<%= yeoman.dist %>/scripts/window/*.js',
+                    '<%= yeoman.dist %>/scripts/window/**/*.js',
+                ],
+                dest: "<%= yeoman.dist %>/scripts/window.min.js"
+            }
+        },
         preprocess: {
             options: {
                 inline: true,

--- a/app/scripts/window/controllers/add_column_dialog_controller.js
+++ b/app/scripts/window/controllers/add_column_dialog_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("AddColumnDialogController", ["$scope", "Events", "mySQLClientService", "$q", "targetObjectService", "typeService", "mySQLQueryService", "sqlExpressionService", function($scope, Events, mySQLClientService, $q, targetObjectService, typeService, mySQLQueryService, sqlExpressionService) {
+chromeMyAdmin.controller("AddColumnDialogController", function($scope, Events, mySQLClientService, $q, targetObjectService, typeService, mySQLQueryService, sqlExpressionService) {
     "use strict";
 
     var onShowDialog = function(table) {
@@ -156,4 +156,4 @@ chromeMyAdmin.controller("AddColumnDialogController", ["$scope", "Events", "mySQ
         }
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/add_column_dialog_controller.js
+++ b/app/scripts/window/controllers/add_column_dialog_controller.js
@@ -1,4 +1,13 @@
-chromeMyAdmin.controller("AddColumnDialogController", function($scope, Events, mySQLClientService, $q, targetObjectService, typeService, mySQLQueryService, sqlExpressionService) {
+chromeMyAdmin.controller("AddColumnDialogController", function(
+    $scope,
+    Events,
+    mySQLClientService,
+    $q,
+    targetObjectService,
+    typeService,
+    mySQLQueryService,
+    sqlExpressionService
+) {
     "use strict";
 
     var onShowDialog = function(table) {

--- a/app/scripts/window/controllers/add_index_dialog_controller.js
+++ b/app/scripts/window/controllers/add_index_dialog_controller.js
@@ -1,4 +1,9 @@
-chromeMyAdmin.controller("AddIndexDialogController", function($scope, Events, mySQLClientService, targetObjectService) {
+chromeMyAdmin.controller("AddIndexDialogController", function(
+    $scope,
+    Events,
+    mySQLClientService,
+    targetObjectService
+) {
     "use strict";
 
     var onShowDialog = function(data) {

--- a/app/scripts/window/controllers/add_index_dialog_controller.js
+++ b/app/scripts/window/controllers/add_index_dialog_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("AddIndexDialogController", ["$scope", "Events", "mySQLClientService", "targetObjectService", function($scope, Events, mySQLClientService, targetObjectService) {
+chromeMyAdmin.controller("AddIndexDialogController", function($scope, Events, mySQLClientService, targetObjectService) {
     "use strict";
 
     var onShowDialog = function(data) {
@@ -131,4 +131,4 @@ chromeMyAdmin.controller("AddIndexDialogController", ["$scope", "Events", "mySQL
         });
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/add_relation_dialog_controller.js
+++ b/app/scripts/window/controllers/add_relation_dialog_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("AddRelationDialogController", ["$scope", "Events", "mySQLClientService", "$q", "targetObjectService", "mySQLQueryService", function($scope, Events, mySQLClientService, $q, targetObjectService, mySQLQueryService) {
+chromeMyAdmin.controller("AddRelationDialogController", function($scope, Events, mySQLClientService, $q, targetObjectService, mySQLQueryService) {
     "use strict";
 
     var onShowDialog = function(table) {
@@ -147,4 +147,4 @@ chromeMyAdmin.controller("AddRelationDialogController", ["$scope", "Events", "my
         });
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/add_relation_dialog_controller.js
+++ b/app/scripts/window/controllers/add_relation_dialog_controller.js
@@ -1,4 +1,11 @@
-chromeMyAdmin.controller("AddRelationDialogController", function($scope, Events, mySQLClientService, $q, targetObjectService, mySQLQueryService) {
+chromeMyAdmin.controller("AddRelationDialogController", function(
+    $scope,
+    Events,
+    mySQLClientService,
+    $q,
+    targetObjectService,
+    mySQLQueryService
+) {
     "use strict";
 
     var onShowDialog = function(table) {

--- a/app/scripts/window/controllers/change_window_panel_controller.js
+++ b/app/scripts/window/controllers/change_window_panel_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("ChangeWindowPanelController", ["$scope", "Events", function($scope, Events) {
+chromeMyAdmin.controller("ChangeWindowPanelController", function($scope, Events) {
     "use strict";
 
     var assignWindowResizeEventHandler = function() {
@@ -65,4 +65,4 @@ chromeMyAdmin.controller("ChangeWindowPanelController", ["$scope", "Events", fun
         });
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/change_window_panel_controller.js
+++ b/app/scripts/window/controllers/change_window_panel_controller.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.controller("ChangeWindowPanelController", function($scope, Events) {
+chromeMyAdmin.controller("ChangeWindowPanelController", function(
+    $scope,
+    Events
+) {
     "use strict";
 
     var assignWindowResizeEventHandler = function() {

--- a/app/scripts/window/controllers/configuration_dialog_controller.js
+++ b/app/scripts/window/controllers/configuration_dialog_controller.js
@@ -1,4 +1,12 @@
-chromeMyAdmin.controller("ConfigurationDialogController", function($scope, mySQLClientService, Events, configurationService, QueryEditorWrapMode, anyQueryExecuteService, ssh2KnownHostService) {
+chromeMyAdmin.controller("ConfigurationDialogController", function(
+    $scope,
+    mySQLClientService,
+    Events,
+    configurationService,
+    QueryEditorWrapMode,
+    anyQueryExecuteService,
+    ssh2KnownHostService
+) {
     "use strict";
 
     var doOpen = function(activeTab) {

--- a/app/scripts/window/controllers/configuration_dialog_controller.js
+++ b/app/scripts/window/controllers/configuration_dialog_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("ConfigurationDialogController", ["$scope", "mySQLClientService", "Events", "configurationService", "QueryEditorWrapMode", "anyQueryExecuteService", "ssh2KnownHostService", function($scope, mySQLClientService, Events, configurationService, QueryEditorWrapMode, anyQueryExecuteService, ssh2KnownHostService) {
+chromeMyAdmin.controller("ConfigurationDialogController", function($scope, mySQLClientService, Events, configurationService, QueryEditorWrapMode, anyQueryExecuteService, ssh2KnownHostService) {
     "use strict";
 
     var doOpen = function(activeTab) {
@@ -99,4 +99,4 @@ chromeMyAdmin.controller("ConfigurationDialogController", ["$scope", "mySQLClien
         return disp;
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/confirm_dialog_controller.js
+++ b/app/scripts/window/controllers/confirm_dialog_controller.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.controller("ConfirmDialogController", function($scope, Events) {
+chromeMyAdmin.controller("ConfirmDialogController", function(
+    $scope,
+    Events
+) {
     "use strict";
 
     var open = function(message, yesButtonLabel, noButtonLabel, danger) {

--- a/app/scripts/window/controllers/confirm_dialog_controller.js
+++ b/app/scripts/window/controllers/confirm_dialog_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("ConfirmDialogController", ["$scope", "Events", function($scope, Events) {
+chromeMyAdmin.controller("ConfirmDialogController", function($scope, Events) {
     "use strict";
 
     var open = function(message, yesButtonLabel, noButtonLabel, danger) {
@@ -29,4 +29,4 @@ chromeMyAdmin.controller("ConfirmDialogController", ["$scope", "Events", functio
         return $scope.danger;
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/create_database_dialog_controller.js
+++ b/app/scripts/window/controllers/create_database_dialog_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("CreateDatabaseDialogController", ["$scope", "Events", "mySQLClientService", "targetObjectService", "mySQLQueryService", function($scope, Events, mySQLClientService, targetObjectService, mySQLQueryService) {
+chromeMyAdmin.controller("CreateDatabaseDialogController", function($scope, Events, mySQLClientService, targetObjectService, mySQLQueryService) {
     "use strict";
 
     var onShowDialog = function() {
@@ -63,4 +63,4 @@ chromeMyAdmin.controller("CreateDatabaseDialogController", ["$scope", "Events", 
         doCreateDatabase();
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/create_database_dialog_controller.js
+++ b/app/scripts/window/controllers/create_database_dialog_controller.js
@@ -1,4 +1,10 @@
-chromeMyAdmin.controller("CreateDatabaseDialogController", function($scope, Events, mySQLClientService, targetObjectService, mySQLQueryService) {
+chromeMyAdmin.controller("CreateDatabaseDialogController", function(
+    $scope,
+    Events,
+    mySQLClientService,
+    targetObjectService,
+    mySQLQueryService
+) {
     "use strict";
 
     var onShowDialog = function() {

--- a/app/scripts/window/controllers/create_routine_dialog_controller.js
+++ b/app/scripts/window/controllers/create_routine_dialog_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("CreateRoutineDialogController", ["$scope", "Events", "mySQLClientService", "typeService", "sqlExpressionService", "targetObjectService", function($scope, Events, mySQLClientService, typeService, sqlExpressionService, targetObjectService) {
+chromeMyAdmin.controller("CreateRoutineDialogController", function($scope, Events, mySQLClientService, typeService, sqlExpressionService, targetObjectService) {
     "use strict";
 
     var onShowDialog = function() {
@@ -150,4 +150,4 @@ chromeMyAdmin.controller("CreateRoutineDialogController", ["$scope", "Events", "
         }
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/create_routine_dialog_controller.js
+++ b/app/scripts/window/controllers/create_routine_dialog_controller.js
@@ -1,4 +1,11 @@
-chromeMyAdmin.controller("CreateRoutineDialogController", function($scope, Events, mySQLClientService, typeService, sqlExpressionService, targetObjectService) {
+chromeMyAdmin.controller("CreateRoutineDialogController", function(
+    $scope,
+    Events,
+    mySQLClientService,
+    typeService,
+    sqlExpressionService,
+    targetObjectService
+) {
     "use strict";
 
     var onShowDialog = function() {

--- a/app/scripts/window/controllers/create_table_dialog_controller.js
+++ b/app/scripts/window/controllers/create_table_dialog_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("CreateTableDialogController", ["$scope", "targetObjectService", "mySQLClientService", "Events", "modeService", "Modes", "Engines", "mySQLQueryService", function($scope, targetObjectService, mySQLClientService, Events, modeService, Modes, Engines, mySQLQueryService) {
+chromeMyAdmin.controller("CreateTableDialogController", function($scope, targetObjectService, mySQLClientService, Events, modeService, Modes, Engines, mySQLQueryService) {
     "use strict";
 
     var loadCharacterSets = function() {
@@ -74,4 +74,4 @@ chromeMyAdmin.controller("CreateTableDialogController", ["$scope", "targetObject
         return $scope.errorMessage.length > 0;
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/create_table_dialog_controller.js
+++ b/app/scripts/window/controllers/create_table_dialog_controller.js
@@ -1,4 +1,13 @@
-chromeMyAdmin.controller("CreateTableDialogController", function($scope, targetObjectService, mySQLClientService, Events, modeService, Modes, Engines, mySQLQueryService) {
+chromeMyAdmin.controller("CreateTableDialogController", function(
+    $scope,
+    targetObjectService,
+    mySQLClientService,
+    Events,
+    modeService,
+    Modes,
+    Engines,
+    mySQLQueryService
+) {
     "use strict";
 
     var loadCharacterSets = function() {

--- a/app/scripts/window/controllers/database_object_list_controller.js
+++ b/app/scripts/window/controllers/database_object_list_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("DatabaseObjectListController", ["$scope", "mySQLClientService", "targetObjectService", "modeService", "Events", "Modes", "mySQLQueryService", "UIConstants", "TableTypes", function($scope, mySQLClientService, targetObjectService, modeService, Events, Modes, mySQLQueryService, UIConstants, TableTypes) {
+chromeMyAdmin.controller("DatabaseObjectListController", function($scope, mySQLClientService, targetObjectService, modeService, Events, Modes, mySQLQueryService, UIConstants, TableTypes) {
     "use strict";
 
     var assignWindowResizeEventHandler = function() {
@@ -223,4 +223,4 @@ chromeMyAdmin.controller("DatabaseObjectListController", ["$scope", "mySQLClient
         }
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/database_object_list_controller.js
+++ b/app/scripts/window/controllers/database_object_list_controller.js
@@ -1,4 +1,14 @@
-chromeMyAdmin.controller("DatabaseObjectListController", function($scope, mySQLClientService, targetObjectService, modeService, Events, Modes, mySQLQueryService, UIConstants, TableTypes) {
+chromeMyAdmin.controller("DatabaseObjectListController", function(
+    $scope,
+    mySQLClientService,
+    targetObjectService,
+    modeService,
+    Events,
+    Modes,
+    mySQLQueryService,
+    UIConstants,
+    TableTypes
+) {
     "use strict";
 
     var assignWindowResizeEventHandler = function() {

--- a/app/scripts/window/controllers/database_panel_controller.js
+++ b/app/scripts/window/controllers/database_panel_controller.js
@@ -1,4 +1,18 @@
-chromeMyAdmin.controller("DatabasePanelController", function($scope, mySQLClientService, modeService, $timeout, UIConstants, Events, Modes, targetObjectService, configurationService, MySQLErrorCode, Templates, $filter, exportAllDatabasesService) {
+chromeMyAdmin.controller("DatabasePanelController", function(
+    $scope,
+    mySQLClientService,
+    modeService,
+    $timeout,
+    UIConstants,
+    Events,
+    Modes,
+    targetObjectService,
+    configurationService,
+    MySQLErrorCode,
+    Templates,
+    $filter,
+    exportAllDatabasesService
+) {
     "use strict";
 
     var autoUpdatePromise = null;

--- a/app/scripts/window/controllers/database_panel_controller.js
+++ b/app/scripts/window/controllers/database_panel_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("DatabasePanelController", ["$scope", "mySQLClientService", "modeService", "$timeout", "UIConstants", "Events", "Modes", "targetObjectService", "configurationService", "MySQLErrorCode", "Templates", "$filter", "exportAllDatabasesService", function($scope, mySQLClientService, modeService, $timeout, UIConstants, Events, Modes, targetObjectService, configurationService, MySQLErrorCode, Templates, $filter, exportAllDatabasesService) {
+chromeMyAdmin.controller("DatabasePanelController", function($scope, mySQLClientService, modeService, $timeout, UIConstants, Events, Modes, targetObjectService, configurationService, MySQLErrorCode, Templates, $filter, exportAllDatabasesService) {
     "use strict";
 
     var autoUpdatePromise = null;
@@ -198,4 +198,4 @@ chromeMyAdmin.controller("DatabasePanelController", ["$scope", "mySQLClientServi
         return _isDatabasePanelVisible();
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/edit_column_dialog_controller.js
+++ b/app/scripts/window/controllers/edit_column_dialog_controller.js
@@ -1,4 +1,13 @@
-chromeMyAdmin.controller("EditColumnDialogController", function($scope, Events, mySQLClientService, $q, targetObjectService, typeService, mySQLQueryService, sqlExpressionService) {
+chromeMyAdmin.controller("EditColumnDialogController", function(
+    $scope,
+    Events,
+    mySQLClientService,
+    $q,
+    targetObjectService,
+    typeService,
+    mySQLQueryService,
+    sqlExpressionService
+) {
     "use strict";
 
     var onShowDialog = function(table, columnDefs, columnStructure) {

--- a/app/scripts/window/controllers/edit_column_dialog_controller.js
+++ b/app/scripts/window/controllers/edit_column_dialog_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("EditColumnDialogController", ["$scope", "Events", "mySQLClientService", "$q", "targetObjectService", "typeService", "mySQLQueryService", "sqlExpressionService", function($scope, Events, mySQLClientService, $q, targetObjectService, typeService, mySQLQueryService, sqlExpressionService) {
+chromeMyAdmin.controller("EditColumnDialogController", function($scope, Events, mySQLClientService, $q, targetObjectService, typeService, mySQLQueryService, sqlExpressionService) {
     "use strict";
 
     var onShowDialog = function(table, columnDefs, columnStructure) {
@@ -266,4 +266,4 @@ chromeMyAdmin.controller("EditColumnDialogController", ["$scope", "Events", "myS
         }
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/er_diagram_panel_controller.js
+++ b/app/scripts/window/controllers/er_diagram_panel_controller.js
@@ -1,4 +1,18 @@
-chromeMyAdmin.controller("ErDiagramPanelController", function($scope, Events, Modes, mySQLClientService, UIConstants, modeService, targetObjectService, mySQLQueryService, TableTypes, relationService, $filter, configurationService, Configurations) {
+chromeMyAdmin.controller("ErDiagramPanelController", function(
+    $scope,
+    Events,
+    Modes,
+    mySQLClientService,
+    UIConstants,
+    modeService,
+    targetObjectService,
+    mySQLQueryService,
+    TableTypes,
+    relationService,
+    $filter,
+    configurationService,
+    Configurations
+) {
     "use strict";
 
     var resetErDiagram = function() {

--- a/app/scripts/window/controllers/er_diagram_panel_controller.js
+++ b/app/scripts/window/controllers/er_diagram_panel_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("ErDiagramPanelController", ["$scope", "Events", "Modes", "mySQLClientService", "UIConstants", "modeService", "targetObjectService", "mySQLQueryService", "TableTypes", "relationService", "$filter", "configurationService", "Configurations", function($scope, Events, Modes, mySQLClientService, UIConstants, modeService, targetObjectService, mySQLQueryService, TableTypes, relationService, $filter, configurationService, Configurations) {
+chromeMyAdmin.controller("ErDiagramPanelController", function($scope, Events, Modes, mySQLClientService, UIConstants, modeService, targetObjectService, mySQLQueryService, TableTypes, relationService, $filter, configurationService, Configurations) {
     "use strict";
 
     var resetErDiagram = function() {
@@ -224,4 +224,4 @@ chromeMyAdmin.controller("ErDiagramPanelController", ["$scope", "Events", "Modes
         $scope.erDiagramAPI = api;
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/error_dialog_controller.js
+++ b/app/scripts/window/controllers/error_dialog_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("ErrorDialogController", ["$scope", "mySQLClientService", "Events", "ErrorLevel", function($scope, mySQLClientService, Events, ErrorLevel) {
+chromeMyAdmin.controller("ErrorDialogController", function($scope, mySQLClientService, Events, ErrorLevel) {
     "use strict";
 
     var onCloseDialog = function() {
@@ -32,4 +32,4 @@ chromeMyAdmin.controller("ErrorDialogController", ["$scope", "mySQLClientService
         });
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/error_dialog_controller.js
+++ b/app/scripts/window/controllers/error_dialog_controller.js
@@ -1,4 +1,9 @@
-chromeMyAdmin.controller("ErrorDialogController", function($scope, mySQLClientService, Events, ErrorLevel) {
+chromeMyAdmin.controller("ErrorDialogController", function(
+    $scope,
+    mySQLClientService,
+    Events,
+    ErrorLevel
+) {
     "use strict";
 
     var onCloseDialog = function() {

--- a/app/scripts/window/controllers/favorite_list_controller.js
+++ b/app/scripts/window/controllers/favorite_list_controller.js
@@ -1,4 +1,10 @@
-chromeMyAdmin.controller("FavoriteListController", function($scope, mySQLClientService, favoriteService, Events, UIConstants) {
+chromeMyAdmin.controller("FavoriteListController", function(
+    $scope,
+    mySQLClientService,
+    favoriteService,
+    Events,
+    UIConstants
+) {
     "use strict";
 
     var assignWindowResizeEventHandler = function() {

--- a/app/scripts/window/controllers/favorite_list_controller.js
+++ b/app/scripts/window/controllers/favorite_list_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("FavoriteListController", ["$scope", "mySQLClientService", "favoriteService", "Events", "UIConstants", function($scope, mySQLClientService, favoriteService, Events, UIConstants) {
+chromeMyAdmin.controller("FavoriteListController", function($scope, mySQLClientService, favoriteService, Events, UIConstants) {
     "use strict";
 
     var assignWindowResizeEventHandler = function() {
@@ -51,4 +51,4 @@ chromeMyAdmin.controller("FavoriteListController", ["$scope", "mySQLClientServic
         favoriteService.selectAndLogin(name);
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/find_rows_with_the_value_dialog_controller.js
+++ b/app/scripts/window/controllers/find_rows_with_the_value_dialog_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("FindRowsWithTheValueDialogController", ["$scope", "Events", "targetObjectService", "mySQLQueryService", "rowsSelectionService", "anyQueryExecuteService", "TableTypes", "sqlExpressionService", function($scope, Events, targetObjectService, mySQLQueryService, rowsSelectionService, anyQueryExecuteService, TableTypes, sqlExpressionService) {
+chromeMyAdmin.controller("FindRowsWithTheValueDialogController", function($scope, Events, targetObjectService, mySQLQueryService, rowsSelectionService, anyQueryExecuteService, TableTypes, sqlExpressionService) {
     "use strict";
 
     var ONLY_SAME_COLUMN_TYPE = "same";
@@ -123,4 +123,4 @@ chromeMyAdmin.controller("FindRowsWithTheValueDialogController", ["$scope", "Eve
         });
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/find_rows_with_the_value_dialog_controller.js
+++ b/app/scripts/window/controllers/find_rows_with_the_value_dialog_controller.js
@@ -1,4 +1,13 @@
-chromeMyAdmin.controller("FindRowsWithTheValueDialogController", function($scope, Events, targetObjectService, mySQLQueryService, rowsSelectionService, anyQueryExecuteService, TableTypes, sqlExpressionService) {
+chromeMyAdmin.controller("FindRowsWithTheValueDialogController", function(
+    $scope,
+    Events,
+    targetObjectService,
+    mySQLQueryService,
+    rowsSelectionService,
+    anyQueryExecuteService,
+    TableTypes,
+    sqlExpressionService
+) {
     "use strict";
 
     var ONLY_SAME_COLUMN_TYPE = "same";

--- a/app/scripts/window/controllers/find_same_rows_dialog_controller.js
+++ b/app/scripts/window/controllers/find_same_rows_dialog_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("FindSameRowsDialogController", ["$scope", "Events", "targetObjectService", "mySQLQueryService", "rowsSelectionService", "TableTypes", "anyQueryExecuteService", function($scope, Events, targetObjectService, mySQLQueryService, rowsSelectionService, TableTypes, anyQueryExecuteService) {
+chromeMyAdmin.controller("FindSameRowsDialogController", function($scope, Events, targetObjectService, mySQLQueryService, rowsSelectionService, TableTypes, anyQueryExecuteService) {
     "use strict";
 
     var onShowDialog = function() {
@@ -147,4 +147,4 @@ chromeMyAdmin.controller("FindSameRowsDialogController", ["$scope", "Events", "t
         });
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/find_same_rows_dialog_controller.js
+++ b/app/scripts/window/controllers/find_same_rows_dialog_controller.js
@@ -1,4 +1,12 @@
-chromeMyAdmin.controller("FindSameRowsDialogController", function($scope, Events, targetObjectService, mySQLQueryService, rowsSelectionService, TableTypes, anyQueryExecuteService) {
+chromeMyAdmin.controller("FindSameRowsDialogController", function(
+    $scope,
+    Events,
+    targetObjectService,
+    mySQLQueryService,
+    rowsSelectionService,
+    TableTypes,
+    anyQueryExecuteService
+) {
     "use strict";
 
     var onShowDialog = function() {

--- a/app/scripts/window/controllers/information_panel_controller.js
+++ b/app/scripts/window/controllers/information_panel_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("InformationPanelController", ["$scope", "mySQLClientService", "modeService", "Events", "Modes", "targetObjectService", "Engines", "UIConstants", "mySQLQueryService", "TableTypes", function($scope, mySQLClientService, modeService, Events, Modes, targetObjectService, Engines, UIConstants, mySQLQueryService, TableTypes) {
+chromeMyAdmin.controller("InformationPanelController", function($scope, mySQLClientService, modeService, Events, Modes, targetObjectService, Engines, UIConstants, mySQLQueryService, TableTypes) {
     "use strict";
 
     var _isInformationPanelVisible = function() {
@@ -180,4 +180,4 @@ chromeMyAdmin.controller("InformationPanelController", ["$scope", "mySQLClientSe
         }
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/information_panel_controller.js
+++ b/app/scripts/window/controllers/information_panel_controller.js
@@ -1,4 +1,15 @@
-chromeMyAdmin.controller("InformationPanelController", function($scope, mySQLClientService, modeService, Events, Modes, targetObjectService, Engines, UIConstants, mySQLQueryService, TableTypes) {
+chromeMyAdmin.controller("InformationPanelController", function(
+    $scope,
+    mySQLClientService,
+    modeService,
+    Events,
+    Modes,
+    targetObjectService,
+    Engines,
+    UIConstants,
+    mySQLQueryService,
+    TableTypes
+) {
     "use strict";
 
     var _isInformationPanelVisible = function() {

--- a/app/scripts/window/controllers/insert_row_dialog_controller.js
+++ b/app/scripts/window/controllers/insert_row_dialog_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("InsertRowDialogController", ["$scope", "targetObjectService", "rowsPagingService", "mySQLClientService", "Events", "sqlExpressionService", "ValueTypes", function($scope, targetObjectService, rowsPagingService, mySQLClientService, Events, sqlExpressionService, ValueTypes) {
+chromeMyAdmin.controller("InsertRowDialogController", function($scope, targetObjectService, rowsPagingService, mySQLClientService, Events, sqlExpressionService, ValueTypes) {
     "use strict";
 
     var resetErrorMessage = function() {
@@ -89,4 +89,4 @@ chromeMyAdmin.controller("InsertRowDialogController", ["$scope", "targetObjectSe
             $scope.valueTypes[columnName] === ValueTypes.DEFAULT;
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/insert_row_dialog_controller.js
+++ b/app/scripts/window/controllers/insert_row_dialog_controller.js
@@ -1,4 +1,12 @@
-chromeMyAdmin.controller("InsertRowDialogController", function($scope, targetObjectService, rowsPagingService, mySQLClientService, Events, sqlExpressionService, ValueTypes) {
+chromeMyAdmin.controller("InsertRowDialogController", function(
+    $scope,
+    targetObjectService,
+    rowsPagingService,
+    mySQLClientService,
+    Events,
+    sqlExpressionService,
+    ValueTypes
+) {
     "use strict";
 
     var resetErrorMessage = function() {

--- a/app/scripts/window/controllers/login_form_controller.js
+++ b/app/scripts/window/controllers/login_form_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("LoginFormController", ["$scope", "$timeout", "mySQLClientService", "favoriteService", "Events", "identityKeepService", "ssh2PortForwardingService", "UIConstants", "ssh2KnownHostService", function($scope, $timeout, mySQLClientService, favoriteService, Events, identityKeepService, ssh2PortForwardingService, UIConstants, ssh2KnownHostService) {
+chromeMyAdmin.controller("LoginFormController", function($scope, $timeout, mySQLClientService, favoriteService, Events, identityKeepService, ssh2PortForwardingService, UIConstants, ssh2KnownHostService) {
     "use strict";
 
     // Private methods
@@ -300,4 +300,4 @@ chromeMyAdmin.controller("LoginFormController", ["$scope", "$timeout", "mySQLCli
         return isUsePortForwarding() && ($scope.ssh2AuthType === "publickey");
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/login_form_controller.js
+++ b/app/scripts/window/controllers/login_form_controller.js
@@ -1,4 +1,14 @@
-chromeMyAdmin.controller("LoginFormController", function($scope, $timeout, mySQLClientService, favoriteService, Events, identityKeepService, ssh2PortForwardingService, UIConstants, ssh2KnownHostService) {
+chromeMyAdmin.controller("LoginFormController", function(
+    $scope,
+    $timeout,
+    mySQLClientService,
+    favoriteService,
+    Events,
+    identityKeepService,
+    ssh2PortForwardingService,
+    UIConstants,
+    ssh2KnownHostService
+) {
     "use strict";
 
     // Private methods

--- a/app/scripts/window/controllers/main_footer_controller.js
+++ b/app/scripts/window/controllers/main_footer_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("MainFooterController", ["$scope", "modeService", "mySQLClientService", "rowsPagingService", "rowsSelectionService", "targetObjectService", "Events", "Modes", "relationSelectionService", "TableTypes", "routineSelectionService", "anyQueryExecuteService", "querySelectionService", "ConfigurationTabs", function($scope, modeService, mySQLClientService, rowsPagingService, rowsSelectionService, targetObjectService, Events, Modes, relationSelectionService, TableTypes, routineSelectionService, anyQueryExecuteService, querySelectionService, ConfigurationTabs) {
+chromeMyAdmin.controller("MainFooterController", function($scope, modeService, mySQLClientService, rowsPagingService, rowsSelectionService, targetObjectService, Events, Modes, relationSelectionService, TableTypes, routineSelectionService, anyQueryExecuteService, querySelectionService, ConfigurationTabs) {
     "use strict";
 
     var showMainStatusMessage = function(message) {
@@ -278,4 +278,4 @@ chromeMyAdmin.controller("MainFooterController", ["$scope", "modeService", "mySQ
         targetObjectService.exportAllDatabases();
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/main_footer_controller.js
+++ b/app/scripts/window/controllers/main_footer_controller.js
@@ -1,4 +1,19 @@
-chromeMyAdmin.controller("MainFooterController", function($scope, modeService, mySQLClientService, rowsPagingService, rowsSelectionService, targetObjectService, Events, Modes, relationSelectionService, TableTypes, routineSelectionService, anyQueryExecuteService, querySelectionService, ConfigurationTabs) {
+chromeMyAdmin.controller("MainFooterController", function(
+    $scope,
+    modeService,
+    mySQLClientService,
+    rowsPagingService,
+    rowsSelectionService,
+    targetObjectService,
+    Events,
+    Modes,
+    relationSelectionService,
+    TableTypes,
+    routineSelectionService,
+    anyQueryExecuteService,
+    querySelectionService,
+    ConfigurationTabs
+) {
     "use strict";
 
     var showMainStatusMessage = function(message) {

--- a/app/scripts/window/controllers/navbar_controller.js
+++ b/app/scripts/window/controllers/navbar_controller.js
@@ -1,4 +1,12 @@
-chromeMyAdmin.controller("NavbarController", function($scope, mySQLClientService, modeService, targetObjectService, Events, Modes, ConfigurationTabs) {
+chromeMyAdmin.controller("NavbarController", function(
+    $scope,
+    mySQLClientService,
+    modeService,
+    targetObjectService,
+    Events,
+    Modes,
+    ConfigurationTabs
+) {
     "use strict";
 
     var loadDatabaseList = function() {

--- a/app/scripts/window/controllers/navbar_controller.js
+++ b/app/scripts/window/controllers/navbar_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("NavbarController", ["$scope", "mySQLClientService", "modeService", "targetObjectService", "Events", "Modes", "ConfigurationTabs", function($scope, mySQLClientService, modeService, targetObjectService, Events, Modes, ConfigurationTabs) {
+chromeMyAdmin.controller("NavbarController", function($scope, mySQLClientService, modeService, targetObjectService, Events, Modes, ConfigurationTabs) {
     "use strict";
 
     var loadDatabaseList = function() {
@@ -152,4 +152,4 @@ chromeMyAdmin.controller("NavbarController", ["$scope", "mySQLClientService", "m
     };
 
 
-}]);
+});

--- a/app/scripts/window/controllers/procedures_functions_panel_controller.js
+++ b/app/scripts/window/controllers/procedures_functions_panel_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("ProceduresFunctionsPanelController", ["$scope", "mySQLClientService", "modeService", "targetObjectService", "UIConstants", "Modes", "Events", "mySQLQueryService", "Templates", "routineSelectionService", "$q", "anyQueryExecuteService", function($scope, mySQLClientService, modeService, targetObjectService, UIConstants, Modes, Events, mySQLQueryService, Templates, routineSelectionService, $q, anyQueryExecuteService) {
+chromeMyAdmin.controller("ProceduresFunctionsPanelController", function($scope, mySQLClientService, modeService, targetObjectService, UIConstants, Modes, Events, mySQLQueryService, Templates, routineSelectionService, $q, anyQueryExecuteService) {
     "use strict";
 
     var initializeRoutinesGrid = function() {
@@ -323,4 +323,4 @@ chromeMyAdmin.controller("ProceduresFunctionsPanelController", ["$scope", "mySQL
         editor.getSession().setUseWrapMode(true);
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/procedures_functions_panel_controller.js
+++ b/app/scripts/window/controllers/procedures_functions_panel_controller.js
@@ -1,4 +1,18 @@
-chromeMyAdmin.controller("ProceduresFunctionsPanelController", function($scope, mySQLClientService, modeService, targetObjectService, UIConstants, Modes, Events, mySQLQueryService, Templates, routineSelectionService, $q, anyQueryExecuteService) {
+chromeMyAdmin.controller("ProceduresFunctionsPanelController"
+,
+function($scope,
+         mySQLClientService,
+         modeService,
+         targetObjectService,
+         UIConstants,
+         Modes,
+         Events,
+         mySQLQueryService,
+         Templates,
+         routineSelectionService,
+         $q,
+         anyQueryExecuteService
+        ) {
     "use strict";
 
     var initializeRoutinesGrid = function() {

--- a/app/scripts/window/controllers/procedures_functions_panel_controller.js
+++ b/app/scripts/window/controllers/procedures_functions_panel_controller.js
@@ -1,18 +1,17 @@
-chromeMyAdmin.controller("ProceduresFunctionsPanelController"
-,
-function($scope,
-         mySQLClientService,
-         modeService,
-         targetObjectService,
-         UIConstants,
-         Modes,
-         Events,
-         mySQLQueryService,
-         Templates,
-         routineSelectionService,
-         $q,
-         anyQueryExecuteService
-        ) {
+chromeMyAdmin.controller("ProceduresFunctionsPanelController", function(
+    $scope,
+    mySQLClientService,
+    modeService,
+    targetObjectService,
+    UIConstants,
+    Modes,
+    Events,
+    mySQLQueryService,
+    Templates,
+    routineSelectionService,
+    $q,
+    anyQueryExecuteService
+) {
     "use strict";
 
     var initializeRoutinesGrid = function() {

--- a/app/scripts/window/controllers/progress_bar_controller.js
+++ b/app/scripts/window/controllers/progress_bar_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("ProgressBarController", ["$scope", "Events", function($scope, Events) {
+chromeMyAdmin.controller("ProgressBarController", function($scope, Events) {
     "use strict";
 
     var assignWindowResizeEventHandler = function() {
@@ -48,4 +48,4 @@ chromeMyAdmin.controller("ProgressBarController", ["$scope", "Events", function(
         return $scope.visibleProgressBar;
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/progress_bar_controller.js
+++ b/app/scripts/window/controllers/progress_bar_controller.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.controller("ProgressBarController", function($scope, Events) {
+chromeMyAdmin.controller("ProgressBarController", function(
+    $scope,
+    Events
+) {
     "use strict";
 
     var assignWindowResizeEventHandler = function() {

--- a/app/scripts/window/controllers/query_panel_controller.js
+++ b/app/scripts/window/controllers/query_panel_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("QueryPanelController", ["$scope", "modeService", "mySQLClientService", "targetObjectService", "UIConstants", "Events", "Modes", "queryHistoryService", "Templates", "configurationService", "Configurations", "$timeout", "querySelectionService", "columnTypeService", "$filter", "clipboardService", function($scope, modeService, mySQLClientService, targetObjectService, UIConstants, Events, Modes, queryHistoryService, Templates, configurationService, Configurations, $timeout, querySelectionService, columnTypeService, $filter, clipboardService) {
+chromeMyAdmin.controller("QueryPanelController", function($scope, modeService, mySQLClientService, targetObjectService, UIConstants, Events, Modes, queryHistoryService, Templates, configurationService, Configurations, $timeout, querySelectionService, columnTypeService, $filter, clipboardService) {
     "use strict";
 
     var initializeQueryResultGrid = function() {
@@ -402,4 +402,4 @@ chromeMyAdmin.controller("QueryPanelController", ["$scope", "modeService", "mySQ
         }
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/query_panel_controller.js
+++ b/app/scripts/window/controllers/query_panel_controller.js
@@ -1,4 +1,21 @@
-chromeMyAdmin.controller("QueryPanelController", function($scope, modeService, mySQLClientService, targetObjectService, UIConstants, Events, Modes, queryHistoryService, Templates, configurationService, Configurations, $timeout, querySelectionService, columnTypeService, $filter, clipboardService) {
+chromeMyAdmin.controller("QueryPanelController", function(
+    $scope,
+    modeService,
+    mySQLClientService,
+    targetObjectService,
+    UIConstants,
+    Events,
+    Modes,
+    queryHistoryService,
+    Templates,
+    configurationService,
+    Configurations,
+    $timeout,
+    querySelectionService,
+    columnTypeService,
+    $filter,
+    clipboardService
+) {
     "use strict";
 
     var initializeQueryResultGrid = function() {

--- a/app/scripts/window/controllers/relation_panel_controller.js
+++ b/app/scripts/window/controllers/relation_panel_controller.js
@@ -1,4 +1,16 @@
-chromeMyAdmin.controller("RelationPanelController", function($scope, mySQLClientService, modeService, Modes, UIConstants, targetObjectService, Events, relationSelectionService, mySQLQueryService, Templates, relationService) {
+chromeMyAdmin.controller("RelationPanelController", function(
+    $scope,
+    mySQLClientService,
+    modeService,
+    Modes,
+    UIConstants,
+    targetObjectService,
+    Events,
+    relationSelectionService,
+    mySQLQueryService,
+    Templates,
+    relationService
+) {
     "use strict";
 
     var initializeRelationGrid = function() {

--- a/app/scripts/window/controllers/relation_panel_controller.js
+++ b/app/scripts/window/controllers/relation_panel_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("RelationPanelController", ["$scope", "mySQLClientService", "modeService", "Modes", "UIConstants", "targetObjectService", "Events", "relationSelectionService", "mySQLQueryService", "Templates", "relationService", function($scope, mySQLClientService, modeService, Modes, UIConstants, targetObjectService, Events, relationSelectionService, mySQLQueryService, Templates, relationService) {
+chromeMyAdmin.controller("RelationPanelController", function($scope, mySQLClientService, modeService, Modes, UIConstants, targetObjectService, Events, relationSelectionService, mySQLQueryService, Templates, relationService) {
     "use strict";
 
     var initializeRelationGrid = function() {
@@ -157,4 +157,4 @@ chromeMyAdmin.controller("RelationPanelController", ["$scope", "mySQLClientServi
         return _isRelationPanelVisible();
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/rows_panel_controller.js
+++ b/app/scripts/window/controllers/rows_panel_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("RowsPanelController", ["$scope", "mySQLClientService", "modeService", "targetObjectService", "$q", "rowsPagingService", "rowsSelectionService", "UIConstants", "Events", "Modes", "sqlExpressionService", "Templates", "mySQLQueryService", "columnTypeService", "clipboardService", function($scope, mySQLClientService, modeService, targetObjectService, $q, rowsPagingService, rowsSelectionService, UIConstants, Events, Modes, sqlExpressionService, Templates, mySQLQueryService, columnTypeService, clipboardService) {
+chromeMyAdmin.controller("RowsPanelController", function($scope, mySQLClientService, modeService, targetObjectService, $q, rowsPagingService, rowsSelectionService, UIConstants, Events, Modes, sqlExpressionService, Templates, mySQLQueryService, columnTypeService, clipboardService) {
     "use strict";
 
     var initializeRowsGrid = function() {
@@ -423,4 +423,4 @@ chromeMyAdmin.controller("RowsPanelController", ["$scope", "mySQLClientService",
         doQueryAndReload();
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/rows_panel_controller.js
+++ b/app/scripts/window/controllers/rows_panel_controller.js
@@ -1,4 +1,20 @@
-chromeMyAdmin.controller("RowsPanelController", function($scope, mySQLClientService, modeService, targetObjectService, $q, rowsPagingService, rowsSelectionService, UIConstants, Events, Modes, sqlExpressionService, Templates, mySQLQueryService, columnTypeService, clipboardService) {
+chromeMyAdmin.controller("RowsPanelController", function(
+    $scope,
+    mySQLClientService,
+    modeService,
+    targetObjectService,
+    $q,
+    rowsPagingService,
+    rowsSelectionService,
+    UIConstants,
+    Events,
+    Modes,
+    sqlExpressionService,
+    Templates,
+    mySQLQueryService,
+    columnTypeService,
+    clipboardService
+) {
     "use strict";
 
     var initializeRowsGrid = function() {

--- a/app/scripts/window/controllers/status_graph_panel_controller.js
+++ b/app/scripts/window/controllers/status_graph_panel_controller.js
@@ -1,4 +1,15 @@
-chromeMyAdmin.controller("StatusGraphPanelController", function($scope, mySQLClientService, modeService, Modes, Events, UIConstants, $timeout, mySQLQueryService, configurationService, GraphTypes) {
+chromeMyAdmin.controller("StatusGraphPanelController", function(
+    $scope,
+    mySQLClientService,
+    modeService,
+    Modes,
+    Events,
+    UIConstants,
+    $timeout,
+    mySQLQueryService,
+    configurationService,
+    GraphTypes
+) {
     "use strict";
 
     var autoUpdatePromise = null;

--- a/app/scripts/window/controllers/status_graph_panel_controller.js
+++ b/app/scripts/window/controllers/status_graph_panel_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("StatusGraphPanelController", ["$scope", "mySQLClientService", "modeService", "Modes", "Events", "UIConstants", "$timeout", "mySQLQueryService", "configurationService", "GraphTypes", function($scope, mySQLClientService, modeService, Modes, Events, UIConstants, $timeout, mySQLQueryService, configurationService, GraphTypes) {
+chromeMyAdmin.controller("StatusGraphPanelController", function($scope, mySQLClientService, modeService, Modes, Events, UIConstants, $timeout, mySQLQueryService, configurationService, GraphTypes) {
     "use strict";
 
     var autoUpdatePromise = null;
@@ -178,4 +178,4 @@ chromeMyAdmin.controller("StatusGraphPanelController", ["$scope", "mySQLClientSe
         $scope.selectedGraphType = graphType;
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/structure_panel_controller.js
+++ b/app/scripts/window/controllers/structure_panel_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("StructurePanelController", ["$scope", "mySQLClientService", "modeService", "targetObjectService", "UIConstants", "$q", "Events", "Modes", "mySQLQueryService", "Templates", "TableTypes", "anyQueryExecuteService", function($scope, mySQLClientService, modeService, targetObjectService, UIConstants, $q, Events, Modes, mySQLQueryService, Templates, TableTypes, anyQueryExecuteService) {
+chromeMyAdmin.controller("StructurePanelController", function($scope, mySQLClientService, modeService, targetObjectService, UIConstants, $q, Events, Modes, mySQLQueryService, Templates, TableTypes, anyQueryExecuteService) {
     "use strict";
 
     var initializeStructureGrid = function() {
@@ -350,4 +350,4 @@ chromeMyAdmin.controller("StructurePanelController", ["$scope", "mySQLClientServ
         }
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/structure_panel_controller.js
+++ b/app/scripts/window/controllers/structure_panel_controller.js
@@ -1,4 +1,17 @@
-chromeMyAdmin.controller("StructurePanelController", function($scope, mySQLClientService, modeService, targetObjectService, UIConstants, $q, Events, Modes, mySQLQueryService, Templates, TableTypes, anyQueryExecuteService) {
+chromeMyAdmin.controller("StructurePanelController", function(
+    $scope,
+    mySQLClientService,
+    modeService,
+    targetObjectService,
+    UIConstants,
+    $q,
+    Events,
+    Modes,
+    mySQLQueryService,
+    Templates,
+    TableTypes,
+    anyQueryExecuteService
+) {
     "use strict";
 
     var initializeStructureGrid = function() {

--- a/app/scripts/window/controllers/update_row_dialog_controller.js
+++ b/app/scripts/window/controllers/update_row_dialog_controller.js
@@ -1,4 +1,13 @@
-chromeMyAdmin.controller("UpdateRowDialogController", function($scope, targetObjectService, Events, sqlExpressionService, mySQLClientService, rowsPagingService, ValueTypes, anyQueryExecuteService) {
+chromeMyAdmin.controller("UpdateRowDialogController", function(
+    $scope,
+    targetObjectService,
+    Events,
+    sqlExpressionService,
+    mySQLClientService,
+    rowsPagingService,
+    ValueTypes,
+    anyQueryExecuteService
+) {
     "use strict";
 
     var resetErrorMessage = function() {

--- a/app/scripts/window/controllers/update_row_dialog_controller.js
+++ b/app/scripts/window/controllers/update_row_dialog_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("UpdateRowDialogController", ["$scope", "targetObjectService", "Events", "sqlExpressionService", "mySQLClientService", "rowsPagingService", "ValueTypes", "anyQueryExecuteService", function($scope, targetObjectService, Events, sqlExpressionService, mySQLClientService, rowsPagingService, ValueTypes, anyQueryExecuteService) {
+chromeMyAdmin.controller("UpdateRowDialogController", function($scope, targetObjectService, Events, sqlExpressionService, mySQLClientService, rowsPagingService, ValueTypes, anyQueryExecuteService) {
     "use strict";
 
     var resetErrorMessage = function() {
@@ -115,4 +115,4 @@ chromeMyAdmin.controller("UpdateRowDialogController", ["$scope", "targetObjectSe
         anyQueryExecuteService.showQueryPanel(sql);
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/window_title_panel_controller.js
+++ b/app/scripts/window/controllers/window_title_panel_controller.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.controller("windowTitlePanelController", ["$scope", "mySQLClientService", "$q", "Events", function($scope, mySQLClientService, $q, Events) {
+chromeMyAdmin.controller("windowTitlePanelController", function($scope, mySQLClientService, $q, Events) {
     "use strict";
 
     var assignEventHandlers = function() {
@@ -64,4 +64,4 @@ chromeMyAdmin.controller("windowTitlePanelController", ["$scope", "mySQLClientSe
         $scope.showChangeWindowPanel();
     };
 
-}]);
+});

--- a/app/scripts/window/controllers/window_title_panel_controller.js
+++ b/app/scripts/window/controllers/window_title_panel_controller.js
@@ -1,4 +1,9 @@
-chromeMyAdmin.controller("windowTitlePanelController", function($scope, mySQLClientService, $q, Events) {
+chromeMyAdmin.controller("windowTitlePanelController", function(
+    $scope,
+    mySQLClientService,
+    $q,
+    Events
+) {
     "use strict";
 
     var assignEventHandlers = function() {

--- a/app/scripts/window/main.js
+++ b/app/scripts/window/main.js
@@ -1,6 +1,15 @@
 var chromeMyAdmin = angular.module("chromeMyAdmin", ["ngGrid", "ui.ace"]);
 
-chromeMyAdmin.run(function($rootScope, Events, ErrorLevel, mySQLClientService, $q, UIConstants, KeyCodes, pingService) {
+chromeMyAdmin.run(function(
+    $rootScope,
+    Events,
+    ErrorLevel,
+    mySQLClientService,
+    $q,
+    UIConstants,
+    KeyCodes,
+    pingService
+) {
     "use strict";
 
     $rootScope.connected = false;

--- a/app/scripts/window/main.js
+++ b/app/scripts/window/main.js
@@ -1,6 +1,6 @@
 var chromeMyAdmin = angular.module("chromeMyAdmin", ["ngGrid", "ui.ace"]);
 
-chromeMyAdmin.run(["$rootScope", "Events", "ErrorLevel", "mySQLClientService", "$q", "UIConstants", "KeyCodes", "pingService", function($rootScope, Events, ErrorLevel, mySQLClientService, $q, UIConstants, KeyCodes, pingService) {
+chromeMyAdmin.run(function($rootScope, Events, ErrorLevel, mySQLClientService, $q, UIConstants, KeyCodes, pingService) {
     "use strict";
 
     $rootScope.connected = false;
@@ -131,7 +131,7 @@ chromeMyAdmin.run(["$rootScope", "Events", "ErrorLevel", "mySQLClientService", "
 
     assignWindowResizeEventHandler();
     adjustMainPanelHeight();
-}]);
+});
 
 chromeMyAdmin.filter("reverse", function() {
     "use strict";

--- a/app/scripts/window/services/any_query_execute_service.js
+++ b/app/scripts/window/services/any_query_execute_service.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.factory("anyQueryExecuteService", function($rootScope, Events) {
+chromeMyAdmin.factory("anyQueryExecuteService", function(
+    $rootScope,
+    Events
+) {
     "use strict";
 
     return {

--- a/app/scripts/window/services/any_query_execute_service.js
+++ b/app/scripts/window/services/any_query_execute_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("anyQueryExecuteService", ["$rootScope", "Events", function($rootScope, Events) {
+chromeMyAdmin.factory("anyQueryExecuteService", function($rootScope, Events) {
     "use strict";
 
     return {
@@ -17,4 +17,4 @@ chromeMyAdmin.factory("anyQueryExecuteService", ["$rootScope", "Events", functio
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/clipboard_service.js
+++ b/app/scripts/window/services/clipboard_service.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.factory("clipboardService", function($rootScope, columnTypeService) {
+chromeMyAdmin.factory("clipboardService", function(
+    $rootScope,
+    columnTypeService
+) {
     "use strict";
 
     return {

--- a/app/scripts/window/services/clipboard_service.js
+++ b/app/scripts/window/services/clipboard_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("clipboardService", ["$rootScope", "columnTypeService", function($rootScope, columnTypeService) {
+chromeMyAdmin.factory("clipboardService", function($rootScope, columnTypeService) {
     "use strict";
 
     return {
@@ -32,4 +32,4 @@ chromeMyAdmin.factory("clipboardService", ["$rootScope", "columnTypeService", fu
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/column_type_service.js
+++ b/app/scripts/window/services/column_type_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("columnTypeService", ["$rootScope", function($rootScope) {
+chromeMyAdmin.factory("columnTypeService", function($rootScope) {
     "use strict";
 
     var numericTypes = [0, 1, 2, 3, 4, 5, 8, 9, 246];
@@ -9,4 +9,4 @@ chromeMyAdmin.factory("columnTypeService", ["$rootScope", function($rootScope) {
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/configuration_service.js
+++ b/app/scripts/window/services/configuration_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("configurationService", ["$rootScope", "$q", "Configurations", function($rootScope, $q, Configurations) {
+chromeMyAdmin.factory("configurationService", function($rootScope, $q, Configurations) {
     "use strict";
 
     var configurationChangeListeners = [];
@@ -119,4 +119,4 @@ chromeMyAdmin.factory("configurationService", ["$rootScope", "$q", "Configuratio
                 showColumnNotNull);
         }
     };
-}]);
+});

--- a/app/scripts/window/services/configuration_service.js
+++ b/app/scripts/window/services/configuration_service.js
@@ -1,4 +1,8 @@
-chromeMyAdmin.factory("configurationService", function($rootScope, $q, Configurations) {
+chromeMyAdmin.factory("configurationService", function(
+    $rootScope,
+    $q,
+    Configurations
+) {
     "use strict";
 
     var configurationChangeListeners = [];

--- a/app/scripts/window/services/export_all_databases_service.js
+++ b/app/scripts/window/services/export_all_databases_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("exportAllDatabasesService", ["$rootScope", "$q", "Events", "mySQLClientService", "mySQLQueryService", "$filter", "typeService", "sqlExpressionService", "TableTypes", function($rootScope, $q, Events, mySQLClientService, mySQLQueryService, $filter, typeService, sqlExpressionService, TableTypes) {
+chromeMyAdmin.factory("exportAllDatabasesService", function($rootScope, $q, Events, mySQLClientService, mySQLQueryService, $filter, typeService, sqlExpressionService, TableTypes) {
     "use strict";
 
     var connectionInfo;
@@ -319,4 +319,4 @@ chromeMyAdmin.factory("exportAllDatabasesService", ["$rootScope", "$q", "Events"
             return deferred.promise;
         }
     };
-}]);
+});

--- a/app/scripts/window/services/export_all_databases_service.js
+++ b/app/scripts/window/services/export_all_databases_service.js
@@ -1,4 +1,14 @@
-chromeMyAdmin.factory("exportAllDatabasesService", function($rootScope, $q, Events, mySQLClientService, mySQLQueryService, $filter, typeService, sqlExpressionService, TableTypes) {
+chromeMyAdmin.factory("exportAllDatabasesService", function(
+    $rootScope,
+    $q,
+    Events,
+    mySQLClientService,
+    mySQLQueryService,
+    $filter,
+    typeService,
+    sqlExpressionService,
+    TableTypes
+) {
     "use strict";
 
     var connectionInfo;

--- a/app/scripts/window/services/favorite_service.js
+++ b/app/scripts/window/services/favorite_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("favoriteService", ["$rootScope", "$q", "Events", function($rootScope, $q, Events) {
+chromeMyAdmin.factory("favoriteService", function($rootScope, $q, Events) {
     "use strict";
 
     var doSelect = function(name) {
@@ -75,4 +75,4 @@ chromeMyAdmin.factory("favoriteService", ["$rootScope", "$q", "Events", function
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/favorite_service.js
+++ b/app/scripts/window/services/favorite_service.js
@@ -1,4 +1,8 @@
-chromeMyAdmin.factory("favoriteService", function($rootScope, $q, Events) {
+chromeMyAdmin.factory("favoriteService", function(
+    $rootScope,
+    $q,
+    Events
+) {
     "use strict";
 
     var doSelect = function(name) {

--- a/app/scripts/window/services/identity_keep_service.js
+++ b/app/scripts/window/services/identity_keep_service.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.factory("identityKeepService", function($rootScope, $q) {
+chromeMyAdmin.factory("identityKeepService", function(
+    $rootScope,
+    $q
+) {
     "use strict";
 
     var getKeyLength = function(map) {

--- a/app/scripts/window/services/identity_keep_service.js
+++ b/app/scripts/window/services/identity_keep_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("identityKeepService", ["$rootScope", "$q", function($rootScope, $q) {
+chromeMyAdmin.factory("identityKeepService", function($rootScope, $q) {
     "use strict";
 
     var getKeyLength = function(map) {
@@ -56,4 +56,4 @@ chromeMyAdmin.factory("identityKeepService", ["$rootScope", "$q", function($root
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/mode_service.js
+++ b/app/scripts/window/services/mode_service.js
@@ -1,4 +1,8 @@
-chromeMyAdmin.factory("modeService", function($rootScope, Events, Modes) {
+chromeMyAdmin.factory("modeService", function(
+    $rootScope,
+    Events,
+    Modes
+) {
     "use strict";
 
     var mode = Modes.DATABASE;

--- a/app/scripts/window/services/mode_service.js
+++ b/app/scripts/window/services/mode_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("modeService", ["$rootScope", "Events", "Modes", function($rootScope, Events, Modes) {
+chromeMyAdmin.factory("modeService", function($rootScope, Events, Modes) {
     "use strict";
 
     var mode = Modes.DATABASE;
@@ -13,4 +13,4 @@ chromeMyAdmin.factory("modeService", ["$rootScope", "Events", "Modes", function(
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/mysql_client_service.js
+++ b/app/scripts/window/services/mysql_client_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("mySQLClientService", ["$q", "$rootScope", function($q, $rootScope) {
+chromeMyAdmin.factory("mySQLClientService", function($q, $rootScope) {
     "use strict";
 
     var mySQLClient = new MySQL.Client();
@@ -300,4 +300,4 @@ chromeMyAdmin.factory("mySQLClientService", ["$q", "$rootScope", function($q, $r
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/mysql_client_service.js
+++ b/app/scripts/window/services/mysql_client_service.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.factory("mySQLClientService", function($q, $rootScope) {
+chromeMyAdmin.factory("mySQLClientService", function(
+    $q,
+    $rootScope
+) {
     "use strict";
 
     var mySQLClient = new MySQL.Client();

--- a/app/scripts/window/services/mysql_query_service.js
+++ b/app/scripts/window/services/mysql_query_service.js
@@ -1,4 +1,8 @@
-chromeMyAdmin.factory("mySQLQueryService", function($q, $rootScope, mySQLClientService) {
+chromeMyAdmin.factory("mySQLQueryService", function(
+    $q,
+    $rootScope,
+    mySQLClientService
+) {
     "use strict";
 
     return {

--- a/app/scripts/window/services/mysql_query_service.js
+++ b/app/scripts/window/services/mysql_query_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("mySQLQueryService", ["$q", "$rootScope", "mySQLClientService", function($q, $rootScope, mySQLClientService) {
+chromeMyAdmin.factory("mySQLQueryService", function($q, $rootScope, mySQLClientService) {
     "use strict";
 
     return {
@@ -186,4 +186,4 @@ chromeMyAdmin.factory("mySQLQueryService", ["$q", "$rootScope", "mySQLClientServ
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/ping_service.js
+++ b/app/scripts/window/services/ping_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("pingService", ["$rootScope", "Events", "$timeout", "mySQLClientService", "Configurations", function($rootScope, Events, $timeout, mySQLClientService, Configurations) {
+chromeMyAdmin.factory("pingService", function($rootScope, Events, $timeout, mySQLClientService, Configurations) {
     "use strict";
 
     var autoPingPromise = null;
@@ -25,4 +25,4 @@ chromeMyAdmin.factory("pingService", ["$rootScope", "Events", "$timeout", "mySQL
 
     return {
     };
-}]);
+});

--- a/app/scripts/window/services/ping_service.js
+++ b/app/scripts/window/services/ping_service.js
@@ -1,4 +1,10 @@
-chromeMyAdmin.factory("pingService", function($rootScope, Events, $timeout, mySQLClientService, Configurations) {
+chromeMyAdmin.factory("pingService", function(
+    $rootScope,
+    Events,
+    $timeout,
+    mySQLClientService,
+    Configurations
+) {
     "use strict";
 
     var autoPingPromise = null;

--- a/app/scripts/window/services/query_history_service.js
+++ b/app/scripts/window/services/query_history_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("queryHistoryService", ["$rootScope", "$q", "Events", function($rootScope, $q, Events) {
+chromeMyAdmin.factory("queryHistoryService", function($rootScope, $q, Events) {
     "use strict";
 
     var trim = function(str) {
@@ -41,4 +41,4 @@ chromeMyAdmin.factory("queryHistoryService", ["$rootScope", "$q", "Events", func
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/query_history_service.js
+++ b/app/scripts/window/services/query_history_service.js
@@ -1,4 +1,8 @@
-chromeMyAdmin.factory("queryHistoryService", function($rootScope, $q, Events) {
+chromeMyAdmin.factory("queryHistoryService", function(
+    $rootScope,
+    $q,
+    Events
+) {
     "use strict";
 
     var trim = function(str) {

--- a/app/scripts/window/services/query_selection_service.js
+++ b/app/scripts/window/services/query_selection_service.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.factory("querySelectionService", function($rootScope, Events) {
+chromeMyAdmin.factory("querySelectionService", function(
+    $rootScope,
+    Events
+) {
     "use strict";
 
     var queryResult = null;

--- a/app/scripts/window/services/query_selection_service.js
+++ b/app/scripts/window/services/query_selection_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("querySelectionService", ["$rootScope", "Events", function($rootScope, Events) {
+chromeMyAdmin.factory("querySelectionService", function($rootScope, Events) {
     "use strict";
 
     var queryResult = null;
@@ -31,4 +31,4 @@ chromeMyAdmin.factory("querySelectionService", ["$rootScope", "Events", function
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/relation_selection_service.js
+++ b/app/scripts/window/services/relation_selection_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("relationSelectionService", ["$rootScope", "Events", function($rootScope, Events) {
+chromeMyAdmin.factory("relationSelectionService", function($rootScope, Events) {
     "use strict";
 
     var selectedRelation = null;
@@ -16,4 +16,4 @@ chromeMyAdmin.factory("relationSelectionService", ["$rootScope", "Events", funct
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/relation_selection_service.js
+++ b/app/scripts/window/services/relation_selection_service.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.factory("relationSelectionService", function($rootScope, Events) {
+chromeMyAdmin.factory("relationSelectionService", function(
+    $rootScope,
+    Events
+) {
     "use strict";
 
     var selectedRelation = null;

--- a/app/scripts/window/services/relation_service.js
+++ b/app/scripts/window/services/relation_service.js
@@ -1,4 +1,8 @@
-chromeMyAdmin.factory("relationService", function($q, $rootScope, mySQLQueryService) {
+chromeMyAdmin.factory("relationService", function(
+    $q,
+    $rootScope,
+    mySQLQueryService
+) {
     "use strict";
 
     var parseForeignKeysFromCreateTableDdl = function(ddl) {

--- a/app/scripts/window/services/relation_service.js
+++ b/app/scripts/window/services/relation_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("relationService", ["$q", "$rootScope", "mySQLQueryService", function($q, $rootScope, mySQLQueryService) {
+chromeMyAdmin.factory("relationService", function($q, $rootScope, mySQLQueryService) {
     "use strict";
 
     var parseForeignKeysFromCreateTableDdl = function(ddl) {
@@ -77,4 +77,4 @@ chromeMyAdmin.factory("relationService", ["$q", "$rootScope", "mySQLQueryService
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/routine_selection_service.js
+++ b/app/scripts/window/services/routine_selection_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("routineSelectionService", ["$rootScope", "Events", function($rootScope, Events) {
+chromeMyAdmin.factory("routineSelectionService", function($rootScope, Events) {
     "use strict";
 
     var selectedRoutine = null;
@@ -23,4 +23,4 @@ chromeMyAdmin.factory("routineSelectionService", ["$rootScope", "Events", functi
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/routine_selection_service.js
+++ b/app/scripts/window/services/routine_selection_service.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.factory("routineSelectionService", function($rootScope, Events) {
+chromeMyAdmin.factory("routineSelectionService", function(
+    $rootScope,
+    Events
+) {
     "use strict";
 
     var selectedRoutine = null;

--- a/app/scripts/window/services/rows_paging_service.js
+++ b/app/scripts/window/services/rows_paging_service.js
@@ -1,4 +1,9 @@
-chromeMyAdmin.factory("rowsPagingService", function($rootScope, Events, configurationService, Configurations) {
+chromeMyAdmin.factory("rowsPagingService", function(
+    $rootScope,
+    Events,
+    configurationService,
+    Configurations
+) {
     "use strict";
 
     var rowCountPerPage = 100;

--- a/app/scripts/window/services/rows_paging_service.js
+++ b/app/scripts/window/services/rows_paging_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("rowsPagingService", ["$rootScope", "Events", "configurationService", "Configurations", function($rootScope, Events, configurationService, Configurations) {
+chromeMyAdmin.factory("rowsPagingService", function($rootScope, Events, configurationService, Configurations) {
     "use strict";
 
     var rowCountPerPage = 100;
@@ -60,4 +60,4 @@ chromeMyAdmin.factory("rowsPagingService", ["$rootScope", "Events", "configurati
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/rows_selection_service.js
+++ b/app/scripts/window/services/rows_selection_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("rowsSelectionService", ["$rootScope", "Events", function($rootScope, Events) {
+chromeMyAdmin.factory("rowsSelectionService", function($rootScope, Events) {
     "use strict";
 
     var selectedRow = null;
@@ -19,4 +19,4 @@ chromeMyAdmin.factory("rowsSelectionService", ["$rootScope", "Events", function(
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/rows_selection_service.js
+++ b/app/scripts/window/services/rows_selection_service.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.factory("rowsSelectionService", function($rootScope, Events) {
+chromeMyAdmin.factory("rowsSelectionService", function(
+    $rootScope,
+    Events
+) {
     "use strict";
 
     var selectedRow = null;

--- a/app/scripts/window/services/sql_expression_service.js
+++ b/app/scripts/window/services/sql_expression_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("sqlExpressionService", ["$rootScope", "ValueTypes", function($rootScope, ValueTypes) {
+chromeMyAdmin.factory("sqlExpressionService", function($rootScope, ValueTypes) {
     "use strict";
 
     var createEqualRightExpression = function(value) {
@@ -84,4 +84,4 @@ chromeMyAdmin.factory("sqlExpressionService", ["$rootScope", "ValueTypes", funct
             return tmp.join(", ");
         }
     };
-}]);
+});

--- a/app/scripts/window/services/sql_expression_service.js
+++ b/app/scripts/window/services/sql_expression_service.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.factory("sqlExpressionService", function($rootScope, ValueTypes) {
+chromeMyAdmin.factory("sqlExpressionService", function(
+    $rootScope,
+    ValueTypes
+) {
     "use strict";
 
     var createEqualRightExpression = function(value) {

--- a/app/scripts/window/services/ssh2_known_host_service.js
+++ b/app/scripts/window/services/ssh2_known_host_service.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.factory("ssh2KnownHostService", function($rootScope, $q) {
+chromeMyAdmin.factory("ssh2KnownHostService", function(
+    $rootScope,
+    $q
+) {
     "use strict";
 
     var lastChecked = null;

--- a/app/scripts/window/services/ssh2_known_host_service.js
+++ b/app/scripts/window/services/ssh2_known_host_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("ssh2KnownHostService", ["$rootScope", "$q", function($rootScope, $q) {
+chromeMyAdmin.factory("ssh2KnownHostService", function($rootScope, $q) {
     "use strict";
 
     var lastChecked = null;
@@ -62,4 +62,4 @@ chromeMyAdmin.factory("ssh2KnownHostService", ["$rootScope", "$q", function($roo
             return deferred.promise;
         }
     };
-}]);
+});

--- a/app/scripts/window/services/ssh2_port_forwarding_service.js
+++ b/app/scripts/window/services/ssh2_port_forwarding_service.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.factory("ssh2PortForwardingService", function($rootScope, $q) {
+chromeMyAdmin.factory("ssh2PortForwardingService", function(
+    $rootScope,
+    $q
+) {
     "use strict";
 
     var deferred;

--- a/app/scripts/window/services/ssh2_port_forwarding_service.js
+++ b/app/scripts/window/services/ssh2_port_forwarding_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("ssh2PortForwardingService", ["$rootScope", "$q", function($rootScope, $q) {
+chromeMyAdmin.factory("ssh2PortForwardingService", function($rootScope, $q) {
     "use strict";
 
     var deferred;
@@ -52,4 +52,4 @@ chromeMyAdmin.factory("ssh2PortForwardingService", ["$rootScope", "$q", function
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/target_object_service.js
+++ b/app/scripts/window/services/target_object_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("targetObjectService", ["$rootScope", "Events", function($rootScope, Events) {
+chromeMyAdmin.factory("targetObjectService", function($rootScope, Events) {
     "use strict";
 
     var database = null;
@@ -101,4 +101,4 @@ chromeMyAdmin.factory("targetObjectService", ["$rootScope", "Events", function($
         }
     };
 
-}]);
+});

--- a/app/scripts/window/services/target_object_service.js
+++ b/app/scripts/window/services/target_object_service.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.factory("targetObjectService", function($rootScope, Events) {
+chromeMyAdmin.factory("targetObjectService", function(
+    $rootScope,
+    Events
+) {
     "use strict";
 
     var database = null;

--- a/app/scripts/window/services/type_service.js
+++ b/app/scripts/window/services/type_service.js
@@ -1,4 +1,7 @@
-chromeMyAdmin.factory("typeService", function($rootScope, TypeMap) {
+chromeMyAdmin.factory("typeService", function(
+    $rootScope,
+    TypeMap
+) {
     "use strict";
 
     var types = [];

--- a/app/scripts/window/services/type_service.js
+++ b/app/scripts/window/services/type_service.js
@@ -1,4 +1,4 @@
-chromeMyAdmin.factory("typeService", ["$rootScope", "TypeMap", function($rootScope, TypeMap) {
+chromeMyAdmin.factory("typeService", function($rootScope, TypeMap) {
     "use strict";
 
     var types = [];
@@ -25,4 +25,4 @@ chromeMyAdmin.factory("typeService", ["$rootScope", "TypeMap", function($rootSco
         }
     };
 
-}]);
+});

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "grunt-shell": "^1.1.1",
     "grunt-svgmin": "^0.2.1",
     "grunt-usemin": "^0.1.13",
+    "grunt-ng-annotate": "^1.0.1",
     "jshint-stylish": "^0.1.5",
     "load-grunt-tasks": "^0.1.3",
     "time-grunt": "^1.0.0"


### PR DESCRIPTION
*Review after you recover from your illness. :ambulance: Take care.*

I found a nice (maybe vital for every angular project) npm package named [ng-annotate](https://github.com/olov/ng-annotate) and its [grunt task](https://github.com/mzgol/grunt-ng-annotate).

So I have successfully eliminated the terribly long controller / service declarations, which makes it tough to add or remove dependencies.
Feel free to comment if you find any misconfiguration of Gruntfile.js, or if you don't like my style.
I'm new to Grunt.